### PR TITLE
use ruby 2.4 in amazon linux 2

### DIFF
--- a/tasks/codedeploy-agent.yaml
+++ b/tasks/codedeploy-agent.yaml
@@ -14,6 +14,11 @@
     - wget
   when: ansible_os_family == "Debian" and ansible_distribution_version != 14.04
 
+- name: Enable repository from amazon-linux-extras packages to install ruby 2.4 in amazon linux 2 distro
+  shell: "amazon-linux-extras enable ruby2.4"
+  when: ansible_distribution == 'Amazon' and (ansible_distribution_version == "(Karoo)" or ansible_distribution_version == "2")
+  changed_when: False
+
 - name: Install from yum when Red Hat based
   yum: name={{item}} state=latest
   with_items:


### PR DESCRIPTION
Install ruby 2.4 when using amazon linux 2: for older version of ruby, like 2.0, codedeploy has nasty bugs and memory leaks when deploying big packages.
Older versions of Ansible (like the one that comes in the default repository of amazon linux 2) have a bug and write "(kaboo)" instead of "2" for ansible_distribution_version, accomodate for this behaviour.